### PR TITLE
Nc return paymenttypes per customer

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,5 +1,6 @@
 """View module for handling requests about customer payment types"""
 import datetime
+from django.contrib.auth.models import User
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -8,19 +9,41 @@ from rest_framework import status
 from bangazonapi.models import Payment, Customer
 
 
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for Customer
+
+    Arguments:
+        serializers
+    """
+    class Meta:
+        model = User
+        fields = ('id', 'first_name', 'last_name')
+
+class CustomerSerializer(serializers.HyperlinkedModelSerializer):
+    """JSON serializer for Customer
+
+    Arguments:
+        serializers
+    """
+    user = UserSerializer()
+    class Meta:
+        model = Customer
+        fields = ('id', 'user')
+
 class PaymentSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for Payment
 
     Arguments:
         serializers
     """
+    customer = CustomerSerializer()
     class Meta:
         model = Payment
         url = serializers.HyperlinkedIdentityField(
             view_name='payment',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'merchant_name', 'account_number', 'expiration_date', 'create_date')
+        fields = ('id', 'url', 'merchant_name', 'account_number', 'expiration_date', 'create_date', 'customer')
 
 class Payments(ViewSet):
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -1,4 +1,5 @@
 """View module for handling requests about customer payment types"""
+import datetime
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -33,7 +34,7 @@ class Payments(ViewSet):
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
         new_payment.expiration_date = request.data["expiration_date"]
-        new_payment.create_date = request.data["create_date"]
+        new_payment.create_date = str(datetime.date.today())
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()
@@ -57,7 +58,7 @@ class Payments(ViewSet):
         except Exception as ex:
             return HttpResponseServerError(ex)
 
-    def destroy(self, request, pk=None):
+    def destroy(self, request, pk):
         """Handle DELETE requests for a single payment type
 
         Returns:

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -83,7 +83,7 @@ class Payments(ViewSet):
         customer_id = self.request.query_params.get('customer', None)
 
         if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            payment_types = payment_types.filter(customer__user=request.auth.user)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,6 +40,7 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
         self.assertEqual(json_response["id"], 1)
+        print(json_response)
 
     def test_delete_payment_type(self):
         """

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -55,6 +55,5 @@ class PaymentTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         #Get Deleted Payment type
-        url = "/paymenttypes/1"
         response = self.client.get(url, None, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -22,7 +22,7 @@ class PaymentTests(APITestCase):
         """
         Ensure we can add a payment type for a customer.
         """
-        # Add product to order
+        # Add payment type
         url = "/paymenttypes"
         data = {
             "merchant_name": "American Express",
@@ -39,25 +39,22 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["account_number"], "111-1111-1111")
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
+        self.assertEqual(json_response["id"], 1)
 
     def test_delete_payment_type(self):
         """
         Ensure we can delete a payment type for a customer.
         """
-        # Add product to order
-        url = "/paymenttypes"
-        data = {
-            "merchant_name": "American Express",
-            "account_number": "111-1111-1111",
-            "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today()
-        }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
-        json_response = json.loads(response.content)
+        # Add payment type
+        self.test_create_payment_type
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(json_response["merchant_name"], "American Express")
-        self.assertEqual(json_response["account_number"], "111-1111-1111")
-        self.assertEqual(json_response["expiration_date"], "2024-12-31")
-        self.assertEqual(json_response["create_date"], str(datetime.date.today()))
+        #Delete Payment type
+        url = "/paymenttypes/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        #Get Deleted Payment type
+        url = "/paymenttypes/1"
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,4 +40,24 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can delete a payment type for a customer.
+        """
+        # Add product to order
+        url = "/paymenttypes"
+        data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(json_response["merchant_name"], "American Express")
+        self.assertEqual(json_response["account_number"], "111-1111-1111")
+        self.assertEqual(json_response["expiration_date"], "2024-12-31")
+        self.assertEqual(json_response["create_date"], str(datetime.date.today()))


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- changed the list of payment types to filter by the user with the token in the headers
- Built some serializers to show more data in the response

## Requests / Responses

**Request**

GET `/paymenttypes` Returns paymenttypes associated with requesting user

Change your default Authentication to:
```
Token 9ba45f09651c5b0c404f37a2d2572c026c14669c
```

See that you receive this response:
```
[
    {
        "id": 3,
        "url": "http://localhost:8000/paymenttypes/3",
        "merchant_name": "Visa",
        "account_number": "fj0398fjw0g89434",
        "expiration_date": "2020-03-01",
        "create_date": "2019-03-11",
        "customer": {
            "id": 7,
            "user": {
                "id": 8,
                "first_name": "Brenda",
                "last_name": "Long"
            }
        }
    }
]
```

## Related Issues

- Fixes #18 