### PR TITLE
Nc products by location

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -33,9 +33,8 @@ class Product(SafeDeleteModel):
         Returns:
             int -- Number items on completed orders
         """
-        sold = OrderProduct.objects.filter(
-            product=self, order__payment_type__isnull=False)
-        return sold.count()
+        sold = OrderProduct.objects.filter(product=self, order__payment_type__isnull=False).count()
+        return sold
 
     @property
     def can_be_rated(self):

--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -57,13 +57,14 @@ class Product(SafeDeleteModel):
             number -- The average rating for the product
         """
         ratings = ProductRating.objects.filter(product=self)
-        if ratings.count() > 1:
-            total_rating = 0
+        total_rating = 0
+        try:
             for rating in ratings:
                 total_rating += rating.rating
             avg = total_rating / len(ratings)
             return avg
-        return 0
+        except ZeroDivisionError:
+            return "No Ratings"
 
     class Meta:
         verbose_name = ("product")

--- a/bangazonapi/views/cart.py
+++ b/bangazonapi/views/cart.py
@@ -20,15 +20,13 @@ class Cart(ViewSet):
             HTTP/1.1 204 No Content
         @apiParam {Number} product_id Id of product to add
         """
-        current_user = Customer.objects.get(user=request.auth.user)
 
         try:
-            open_order = Order.objects.get(
-                customer=current_user, payment_type__isnull=True)
+            open_order = Order.objects.get(customer__user=request.auth.user, payment_type__isnull=True)
         except Order.DoesNotExist as ex:
             open_order = Order()
             open_order.created_date = datetime.datetime.now()
-            open_order.customer = current_user
+            open_order.customer = Customer.objects.get(user=request.auth.user)
             open_order.save()
 
         line_item = OrderProduct()

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -78,6 +78,10 @@ class Payments(ViewSet):
             serializer = PaymentSerializer(
                 payment_type, context={'request': request})
             return Response(serializer.data)
+
+        except Payment.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -101,12 +101,7 @@ class Payments(ViewSet):
 
     def list(self, request):
         """Handle GET requests to payment type resource"""
-        payment_types = Payment.objects.all()
-
-        customer_id = self.request.query_params.get('customer', None)
-
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__user=request.auth.user)
+        payment_types = Payment.objects.filter(customer__user=request.auth.user)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -272,7 +272,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -254,6 +254,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        location = self.request.query_params.get('location', None)
 
         if order is not None:
             order_filter = order
@@ -277,6 +278,9 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -236,7 +236,6 @@ class Profile(ViewSet):
 
             try:
                 open_order = Order.objects.get(customer=current_user)
-                print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()
                 open_order.created_date = datetime.datetime.now()

--- a/tests/order.py
+++ b/tests/order.py
@@ -113,4 +113,22 @@ class OrderTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["payment_type"], "http://testserver/paymenttypes/1")
 
-    # TODO: New line item is not added to closed order
+    def test_new_line_item_not_added_to_closed_order(self):
+        """
+        Ensure we can add a payment type to an order.
+        """
+        # Add product
+        self.test_add_product_to_order()
+        # Close that order with a payment type
+        self.test_add_payment_type_to_order()
+        # Add another product to an order
+        self.test_add_product_to_order()
+
+        # Get open order # 2 that should now exist
+        url = "/orders/2"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["payment_type"], None)

--- a/tests/order.py
+++ b/tests/order.py
@@ -121,11 +121,15 @@ class OrderTests(APITestCase):
         # Add Product/Create Order and Close that order with a payment type
         self.test_add_payment_type_to_order()
         # Add another product to an order
-        self.test_add_product_to_order()
+        url = "/cart"
+        data = { "product_id": 1 }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Get open order # 2 that should now exist
         url = "/orders/2"
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -117,9 +117,8 @@ class OrderTests(APITestCase):
         """
         Ensure we can add a payment type to an order.
         """
-        # Add product
-        self.test_add_product_to_order()
-        # Close that order with a payment type
+        
+        # Add Product/Create Order and Close that order with a payment type
         self.test_add_payment_type_to_order()
         # Add another product to an order
         self.test_add_product_to_order()

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,7 +40,6 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
         self.assertEqual(json_response["id"], 1)
-        print(json_response)
 
     def test_delete_payment_type(self):
         """

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -47,7 +47,7 @@ class PaymentTests(APITestCase):
         Ensure we can delete a payment type for a customer.
         """
         # Add payment type
-        self.test_create_payment_type
+        self.test_create_payment_type()
 
         #Delete Payment type
         url = "/paymenttypes/1"

--- a/tests/product.py
+++ b/tests/product.py
@@ -126,7 +126,7 @@ class ProductTests(APITestCase):
         self.assertEqual(json_response["location"], "Pittsburgh")
         self.assertEqual(json_response["average_rating"], 4.5)
 
-    def test_add_product_rating(self):
+    def test_delete_product(self):
         """
         Ensure we can delete a product.
         """


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Did a try/except block instead of if block for dividing by zero ratings
- Added a location query param to find a location by string

## Requests / Responses

**Request**

GET `http://localhost:8000/products?location=ong`

**Response**

HTTP/1.1 200 OK

```json
[
    {
        "id": 1,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 0,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Onguday",
        "image_path": null,
        "average_rating": "No Ratings"
    },
    {
        "id": 2,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 0,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Zhongshan",
        "image_path": null,
        "average_rating": "No Ratings"
    },
    {
        "id": 27,
        "name": "Range Rover",
        "price": 1564.25,
        "number_sold": 0,
        "description": "2002 Land Rover",
        "quantity": 1,
        "created_date": "2019-05-14",
        "location": "Yong’an",
        "image_path": null,
        "average_rating": "No Ratings"
    }
]
```

## Testing

Description of how to test code...

- See that the locations match the param in the request
- See that there is no error by dividing by zero
- Zero ratings now return "no ratings"


## Related Issues

- Fixes #14