### PR TITLE
Nc duplicate line iten key

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -9,25 +9,8 @@ from rest_framework.decorators import action
 from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
 from .product import ProductSerializer
 
-
-class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
-
-    product = ProductSerializer(many=False)
-
-    class Meta:
-        model = OrderProduct
-        url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
-        )
-        fields = ('id', 'product')
-        depth = 1
-
 class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
-
-    lineitems = OrderLineItemSerializer(many=True)
 
     class Meta:
         model = Order
@@ -35,7 +18,7 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        fields = ('id', 'url', 'created_date', 'payment_type', 'customer')
 
 
 class Orders(ViewSet):

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -113,8 +113,7 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message.
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type__isnull=True)
                 line_items = OrderProduct.objects.filter(order=open_order)
                 line_items.delete()
                 open_order.delete()

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -175,15 +175,12 @@ class Profile(ViewSet):
             @apiError (404) {String} message  Not found message
             """
             try:
-                open_order = Order.objects.get(
-                    customer=current_user, payment_type=None)
+                open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
-                line_items = LineItemSerializer(
-                    line_items, many=True, context={'request': request})
+                line_items = LineItemSerializer(line_items, many=True, context={'request': request})
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={
-                                                'request': request}).data
+                cart["order"] = OrderSerializer(open_order, many=False, context={'request': request}).data
                 cart["order"]["line_items"] = line_items.data
                 cart["order"]["size"] = len(line_items.data)
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -59,7 +59,6 @@ class OrderTests(APITestCase):
         self.assertEqual(json_response["size"], 1)
         self.assertEqual(len(json_response["lineitems"]), 1)
 
-
     def test_remove_product_from_order(self):
         """
         Ensure we can remove a product from an order.
@@ -72,6 +71,30 @@ class OrderTests(APITestCase):
         data = { "product_id": 1 }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify product was removed
+        url = "/cart"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["size"], 0)
+        self.assertEqual(len(json_response["lineitems"]), 0)
+
+    def test_remove_product_from_order_by_line_item(self):
+        """
+        Ensure we can remove a product from an order.
+        """
+        # Add product
+        self.test_add_product_to_order()
+
+        # Remove product from cart
+        url = "/lineitems/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, None, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -175,9 +175,4 @@ class ProductTests(APITestCase):
         }
         response = self.client.post(url, data, format='json')
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(json_response["name"], "Kite")
-        self.assertEqual(json_response["price"], 17501)
-        self.assertEqual(json_response["quantity"], 60)
-        self.assertEqual(json_response["description"], "It flies high")
-        self.assertEqual(json_response["location"], "Pittsburgh")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Removed lineitems from orderserializer in the order.py view
- removed lineitemserializer from the order.py view

## Requests / Responses

**Request**

GET `http://localhost:8000/profile/cart`

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 2,
    "url": "http://localhost:8000/orders/2",
    "created_date": "2019-04-12",
    "payment_type": null,
    "customer": "http://localhost:8000/customers/7",
    "line_items": [
        {
            "id": 5,
            "product": {
                "id": 33,
                "name": "Stratus",
                "price": 1199.91,
                "number_sold": 0,
                "description": "2001 Dodge",
                "quantity": 1,
                "created_date": "2019-04-06",
                "location": "Tianning",
                "image_path": null,
                "average_rating": "No Ratings"
            }
        },
        {
            "id": 6,
            "product": {
                "id": 71,
                "name": "Sebring",
                "price": 1045.66,
                "number_sold": 0,
                "description": "1999 Chrysler",
                "quantity": 4,
                "created_date": "2019-05-18",
                "location": "Namibe",
                "image_path": null,
                "average_rating": "No Ratings"
            }
        }
    ],
    "size": 2
}
```

## Testing

See that the `"lineitems"` key no longer exists

## Related Issues

- Fixes #24